### PR TITLE
Windows builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,23 +18,32 @@
 				} ],
 				[ 'OS == "win"', {
 					'actions' : [ {
-						'action_name' : 'esql-preprocess',
+						'action_name' : 'prepare',
 						'inputs' : [
 							'src/esqlc.ecpp'
 						],
 						'outputs' : [
-							'esqlc.C'
+							'<(INTERMEDIATE_DIR)/src/esqlc.ec'
+						],
+						'action' : [ 'copy', 'src/esqlc.ecpp', '<(INTERMEDIATE_DIR)/src/esqlc.ec' ]
+					}, {
+						'action_name' : 'esql-preprocess',
+						'inputs' : [
+							'<(INTERMEDIATE_DIR)/src/esqlc.ec'
+						],
+						'outputs' : [
+							'build/esqlc.c'
 						],
 						'action' : [ 'esql', '-thread', '-e', '<@(_inputs)' ]
 					}, {
 						'action_name' : 'move',
 						'inputs' : [
-							'esqlc.C'
+							'build/esqlc.c'
 						],
 						'outputs' : [
 							'<(SHARED_INTERMEDIATE_DIR)/src/esqlc.cpp'
 						],
-						'action' : [ 'move', 'esqlc.C', '<(SHARED_INTERMEDIATE_DIR)/src/esqlc.cpp' ]
+						'action' : [ 'move', 'build/esqlc.c', '<(SHARED_INTERMEDIATE_DIR)/src/esqlc.cpp' ]
 					} ]
 				} ]
 			]
@@ -55,6 +64,14 @@
 				'<(SHARED_INTERMEDIATE_DIR)/src/esqlc.cpp',
 			],
 			'conditions' : [
+				[ '(OS == "linux" or OS == "mac")', {
+					'link_settings' : {
+						'libraries' : [
+							'-L$(INFORMIXDIR)/lib',
+							'-L$(INFORMIXDIR)/lib/esql',
+						]
+					}
+				} ],
 				[ 'OS == "mac"', {
 					'link_settings' : {
 						'libraries' : [
@@ -75,7 +92,15 @@
 				[ 'OS == "win"', {
 					'link_settings' : {
 						'libraries' : [
-							'<!@(esql -static -thread -libs)'
+							'$(INFORMIXDIR)/lib/isqlt09a.lib',
+							'$(INFORMIXDIR)/lib/igl4n304.lib',
+							'$(INFORMIXDIR)/lib/iglxn304.lib',
+							'$(INFORMIXDIR)/lib/igo4n304.lib',
+							'netapi32.lib',
+							'wsock32.lib',
+							'user32.lib',
+							'winmm.lib',
+							'advapi32.lib'
 						]
 					}
 				} ]
@@ -86,15 +111,9 @@
 			],
 			'include_dirs' : [
 				'<!(node -e "require(\'nan\')")',
-				'<!(echo ${INFORMIXDIR}/incl/esql)',
+				'$(INFORMIXDIR)/incl/esql',
 				'src'
-			],
-			'link_settings' : {
-				'libraries' : [
-					'-L<!(echo ${INFORMIXDIR}/lib)',
-					'-L<!(echo ${INFORMIXDIR}/lib/esql)',
-				]
-			}
+			]
 		}
 	]
 }

--- a/src/esqlc.ecpp
+++ b/src/esqlc.ecpp
@@ -11,11 +11,28 @@ int32_t esqlc::connect( const char * connid, const char * database, const char *
 
 	const char * esql_db = database;
 	const char * esql_connid = connid;
+
+#ifndef _WIN32
 	const char * esql_user = username;
 	const char * esql_pass = password;
+#else
+	char * esql_user = 0;
+	char * esql_pass = 0;
+#endif
 
 	EXEC SQL END DECLARE SECTION;
 
+#ifdef _WIN32
+	if ( username ) {
+		esql_user = new char[ sizeof( username ) ];
+		std::strncpy( esql_user, username, sizeof( username ) );
+	}
+
+	if ( password ) {
+		esql_pass = new char[ sizeof( password ) ];
+		std::strncpy( esql_pass, password, sizeof( password ) );
+	}
+#endif
 
 	if ( username && strlen( username ) && password && strlen( password ) ) {
 		EXEC SQL connect to :esql_db as :esql_connid USER :esql_user USING :esql_pass
@@ -27,8 +44,13 @@ int32_t esqlc::connect( const char * connid, const char * database, const char *
 		EXEC SQL connect to :esql_db as :esql_connid WITH CONCURRENT TRANSACTION;
 	}
 
-	return SQLCODE;
 
+#ifdef _WIN32
+	if ( esql_user ) { delete [] esql_user; }
+	if ( esql_pass ) { delete [] esql_pass; }
+#endif
+
+	return SQLCODE;
 };
 
 

--- a/src/esqlc.ecpp
+++ b/src/esqlc.ecpp
@@ -23,21 +23,21 @@ int32_t esqlc::connect( const char * connid, const char * database, const char *
 	EXEC SQL END DECLARE SECTION;
 
 #ifdef _WIN32
-	if ( username ) {
-		esql_user = new char[ sizeof( username ) ];
-		std::strncpy( esql_user, username, sizeof( username ) );
+	if ( username && std::strlen( username ) ) {
+		esql_user = new char[ ( std::strlen( username ) + 1 ) ];
+		std::strncpy( esql_user, username, ( std::strlen( username ) + 1 ) );
 	}
 
-	if ( password ) {
-		esql_pass = new char[ sizeof( password ) ];
-		std::strncpy( esql_pass, password, sizeof( password ) );
+	if ( password && std::strlen( password ) ) {
+		esql_pass = new char[ ( std::strlen( password ) + 1 ) ];
+		std::strncpy( esql_pass, password, ( std::strlen( password ) + 1 ) );
 	}
 #endif
 
-	if ( username && strlen( username ) && password && strlen( password ) ) {
+	if ( username && std::strlen( username ) && password && std::strlen( password ) ) {
 		EXEC SQL connect to :esql_db as :esql_connid USER :esql_user USING :esql_pass
 			WITH CONCURRENT TRANSACTION;
-	} else if ( username && strlen( username ) ) {
+	} else if ( username && std::strlen( username ) ) {
 		EXEC SQL connect to :esql_db as :esql_connid USER :esql_user
 			WITH CONCURRENT TRANSACTION;
 	} else {
@@ -51,6 +51,7 @@ int32_t esqlc::connect( const char * connid, const char * database, const char *
 #endif
 
 	return SQLCODE;
+
 };
 
 

--- a/src/ifx/ifx.cpp
+++ b/src/ifx/ifx.cpp
@@ -289,7 +289,7 @@ namespace ifx {
 				insqlda->sqlvar   = new ifx_sqlvar_t[ args->Length() ];
 				insqlda->desc_occ = 0;
 
-				std::memset( insqlda->sqlvar, 0, sizeof( ifx_sqlvar_t[ args->Length() ] ) );
+				std::memset( insqlda->sqlvar, 0, ( sizeof( ifx_sqlvar_t ) * args->Length() ) );
 
 
 				for ( uint32_t i = 0; i < args->Length(); i++ ) {

--- a/src/ifx/workers/fetch.cpp
+++ b/src/ifx/workers/fetch.cpp
@@ -6,6 +6,13 @@
 #include "fetch.h"
 #include "../../esqlc.h"
 
+#ifdef _WIN32
+extern "C" {
+	mint __cdecl dectoasc(struct decimal *np,char *cp,mint len,mint right);
+	mint __cdecl dectolong(struct decimal *np,int32_t *lngp);
+}
+#endif
+
 
 namespace ifx {
 namespace workers {

--- a/src/ifx/workers/fetch.cpp
+++ b/src/ifx/workers/fetch.cpp
@@ -6,13 +6,6 @@
 #include "fetch.h"
 #include "../../esqlc.h"
 
-#ifdef _WIN32
-extern "C" {
-	mint __cdecl dectoasc(struct decimal *np,char *cp,mint len,mint right);
-	mint __cdecl dectolong(struct decimal *np,int32_t *lngp);
-}
-#endif
-
 
 namespace ifx {
 namespace workers {
@@ -92,7 +85,8 @@ namespace workers {
 				case SQLMONEY:
 				case SQLDECIMAL:
 					{
-						int32_t n = 0;
+						// have to use informix integer types here so it doesn't complain on windows
+						int4 n = 0;
 						if ( dectolong( reinterpret_cast< dec_t * >( sqlvar->sqldata ), &n ) == 0 ) {
 							result->Set( Nan::New< v8::Integer >( i ), Nan::New< v8::Number >( n ) );
 						} else {


### PR DESCRIPTION
Work on getting the native addon to compiles on Windows.

Having tested it on a Windows 7 (32-bit) VM, the native addon compiles successfully and the **ifx** tests passes. However, there seems to be some strange behaviour when Promises and callbacks are mixed. 

e.g. [examples/informix.example.js](https://github.com/nukedzn/node-informix/blob/master/examples/informix.example.js) wouldn't give consistent results
```
> node examples/informix.example.js
[stmt] results: [ [ 0 ] ]
[query] results: [ [ 'systabauth' ],
  [ 'syscolauth' ],
  [ 'sysprocauth' ],
  [ 'sysfragauth' ],
  [ 'sysroleauth' ],
  [ 'sysxtdtypeauth' ],
  [ 'syslangauth' ],
  [ 'sysseclabelauth' ],
  [ 'syssurrogateauth' ] ]

> node examples/informix.example.js
[stmt] results: [ [ 0 ] ]

> node examples/informix.example.js
[stmt] results: [ [ 0 ] ]
```

It seems like Node.js ends the process prematurely presumably because it thinks the promise chain for ```informix.query()``` wouldn't resolve. 

Moving [src/ifx/workers/stmtfree.cpp:51](https://github.com/nukedzn/node-informix/blob/master/src/ifx/workers/stmtfree.cpp#L51) to be after ```callback->Call( 2, argv );``` (line 59) would make the above example to give consistent results but I'm not sure why!!!

Also, replacing [lib/statement.js:119](https://github.com/nukedzn/node-informix/blob/master/lib/statement.js#L119) with;
```js
setTimeout( function () {
	resolve( self.$.id );
}, 10 );
```
would also produce consistent results. 

