### PR TITLE
Make it possible to name statements when preparing

### DIFF
--- a/lib/informix.js
+++ b/lib/informix.js
@@ -67,17 +67,23 @@ Informix.prototype.options = function ( opts ) {
 *   Prepare a statement
 *
 *   @param {string} sql - SQL statement to prepare
+*   @param {string} [name] - Statement name
 *   @return {Promise.<Statement, Error>} - A promise to a statement object or an
 *           Error if rejected.
 */
-Informix.prototype.prepare = function ( sql ) {
+Informix.prototype.prepare = function ( sql, name ) {
 
 	var self = this;
+	var opts;
+
+	if ( ( typeof name === 'string' ) && name.length > 0 ) {
+		opts = { id : name };
+	}
 
 	return self.$.pool.acquire()
 		.then( function ( conn ) {
 			self.$.pool.release( conn );
-			return conn.prepare( sql );
+			return conn.prepare( sql, opts );
 		} )
 		.catch( function ( err ) {
 			self.emit( 'error', err );

--- a/test/lib.informix.test.js
+++ b/test/lib.informix.test.js
@@ -54,7 +54,7 @@ describe( 'lib/Informix', function () {
 
 	it( 'should be possible to prepare a named statement', function () {
 		var informix = new Informix( opts );
-		var stmtname = 'stmt:01';
+		var stmtname = 'stmt_select';
 		return informix.prepare( 'select count(*) from tcustomers where id > ?;', stmtname )
 			.then( function ( stmt ) {
 				expect( stmt.$.id ).to.eql( stmtname );

--- a/test/lib.informix.test.js
+++ b/test/lib.informix.test.js
@@ -52,6 +52,16 @@ describe( 'lib/Informix', function () {
 			} );
 	} );
 
+	it( 'should be possible to prepare a named statement', function () {
+		var informix = new Informix( opts );
+		var stmtname = 'stmt:01';
+		return informix.prepare( 'select count(*) from tcustomers where id > ?;', stmtname )
+			.then( function ( stmt ) {
+				expect( stmt.$.id ).to.eql( stmtname );
+				return stmt.free();
+			} );
+	} );
+
 	it( 'should be possible to create a new context', function () {
 		var informix = new Informix( opts );
 		var ctx = informix.createContext();


### PR DESCRIPTION
Using a `sha256` hash for statement IDs might not work with older versions of Informix (<9.2x) (see #33).

So make it possible to name statements when preparing (`informix.prepare()`). 