### PR TITLE
Named cursors

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -10,16 +10,19 @@ var uuid = require( 'uuid' );
 *   @constructor
 *   @param {Connection} conn - Connection object
 *   @param {Statement} stmt - Statement object
+*   @param {object} [opts] - Constructor options
+*   @param {string} [opts.id] - Cursor id to use
 */
-var Cursor = function ( conn, stmt ) {
+var Cursor = function ( conn, stmt, opts ) {
 
 	// privileged data
 	this.$ = {
 		conn : conn,
-		id   : '_' + uuid.v4().replace( /\-/g, 's' ),
 		ifx  : conn.ifx(),
 		stmt : stmt
 	};
+
+	this.options( opts );
 
 };
 
@@ -167,6 +170,22 @@ Cursor.prototype.fetchAll = function ( opts ) {
 			return results;
 		} );
 
+};
+
+
+/**
+*   Set options
+*
+*   @param {object} opts - Options
+*/
+Cursor.prototype.options = function ( opts ) {
+	this.$.opts = opts || {};
+
+	if ( (typeof this.$.opts.id) === 'string' ) {
+		this.$.id = this.$.opts.id;
+	} else {
+		this.$.id = '_' + uuid.v4().replace( /\-/g, 's' );
+	}
 };
 
 

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -42,19 +42,26 @@ Statement.prototype.context = function () {
 *
 *   @param {string|Array} [args] - Arguments to be used when executing the
 *          prepared statement.
-
+*   @param {object} [opts] - Cursor options.
+*
 *   @return {Promise.<Cursor, Error>} - A promise to a results cursor object or
 *           an Error if rejected.
 */
-Statement.prototype.exec = function ( args ) {
+Statement.prototype.exec = function ( args, opts ) {
 
 	var self = this;
+	if ( ( typeof args ) === 'object' ) {
+		opts = args;
+		args = undefined;
+	} else {
+		opts = opts || {};
+	}
 
 	return self.$.conn.acquire( self.context() )
 		.then( function ( conn ) {
 			return new Promise( function ( resolve, reject ) {
 				var Cursor = require( './cursor' );
-				var cursor = new Cursor( self.$.conn, self );
+				var cursor = new Cursor( self.$.conn, self, opts );
 
 				if ( args !== undefined ) {
 					self.$.ifx.exec( conn.id(), self.$.id, cursor.id(), args, function ( err, curid ) {

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -50,7 +50,7 @@ Statement.prototype.context = function () {
 Statement.prototype.exec = function ( args, opts ) {
 
 	var self = this;
-	if ( ( typeof args ) === 'object' ) {
+	if ( ( typeof args ) === 'object' && !Array.isArray( args ) ) {
 		opts = args;
 		args = undefined;
 	} else {

--- a/test/lib.statement.test.js
+++ b/test/lib.statement.test.js
@@ -161,8 +161,9 @@ describe( 'lib/Statement', function () {
 			it( 'should be possible to execute the statement with cursor options', function () {
 				var curname = 'cursor_select';
 				return stmt.exec( 0, { id : curname } )
-					.then( function ( c ) {
-						expect( c.$.id ).to.eql( curname );
+					.then( function ( cursor ) {
+						expect( cursor.$.id ).to.eql( curname );
+						return cursor.close();
 					} );
 			} );
 		} );
@@ -207,8 +208,9 @@ describe( 'lib/Statement', function () {
 			it( 'should be possible to execute the statement with cursor options', function () {
 				var curname = 'stmt_select';
 				return stmt.exec( { id : curname } )
-					.then( function ( c ) {
-						expect( c.$.id ).to.eql( curname );
+					.then( function ( cursor ) {
+						expect( cursor.$.id ).to.eql( curname );
+						return cursor.close();
 					} );
 			} );
 		} );

--- a/test/lib.statement.test.js
+++ b/test/lib.statement.test.js
@@ -157,6 +157,14 @@ describe( 'lib/Statement', function () {
 						expect( err.message ).to.be.string( '[-254] Too many or too few host variables given.' );
 					} );
 			} );
+
+			it( 'should be possible to execute the statement with cursor options', function () {
+				var curname = 'cursor_select';
+				return stmt.exec( 0, { id : curname } )
+					.then( function ( c ) {
+						expect( c.$.id ).to.eql( curname );
+					} );
+			} );
 		} );
 
 	} );
@@ -193,6 +201,14 @@ describe( 'lib/Statement', function () {
 					.catch( function ( err ) {
 						expect( err ).to.be.an.instanceof( Error );
 						expect( err.message ).to.be.string( 'This statment does not expect any input arguments.' );
+					} );
+			} );
+
+			it( 'should be possible to execute the statement with cursor options', function () {
+				var curname = 'stmt_select';
+				return stmt.exec( { id : curname } )
+					.then( function ( c ) {
+						expect( c.$.id ).to.eql( curname );
 					} );
 			} );
 		} );


### PR DESCRIPTION
Make it possible to name cursors rather than using a UUID v4 variant all the time (relates to #33, #34). 