### PR TITLE
Free ifx_sqlda_t in stmt_t using SqlFreeMem on Windows.

### DIFF
--- a/src/ifx/types.h
+++ b/src/ifx/types.h
@@ -7,6 +7,7 @@
 #include <list>
 #include <sqlda.h>
 #include <sqltypes.h>
+#include <sqlhdr.h>
 
 
 namespace ifx {
@@ -76,13 +77,13 @@ namespace ifx {
 				delete it->second;
 			}
 
-			if ( insqlda ) {
-				delete insqlda;
-			}
-
-			if ( outsqlda ) {
-				delete outsqlda;
-			}
+#if _WIN32
+			SqlFreeMem( insqlda, SQLDA_FREE );
+			SqlFreeMem( outsqlda, SQLDA_FREE );
+#else
+			free( insqlda );
+			free( outsqlda );
+#endif
 
 		}
 	};


### PR DESCRIPTION
On Windows, SqlFreeMem() should be used to free memory for sqlda
structures allocated by DESCRIBE. Otherwise free() should be used.

See IBM docs at https://tinyurl.com/y7648d3m.

Without this, the application crashes in stmt_t destructor causing
results not being returned. This may be relevant to issue #31.