### PR TITLE
Allow 64bit integer columns to work

### DIFF
--- a/src/ifx/workers/fetch.cpp
+++ b/src/ifx/workers/fetch.cpp
@@ -76,6 +76,11 @@ namespace workers {
 					result->Set( Nan::New< v8::Integer >( i ), Nan::New< v8::Int32 >(* reinterpret_cast<int32_t *>( sqlvar->sqldata ) ) );
 					break;
 
+				case SQLINFXBIGINT:
+				case SQLBIGSERIAL:
+					result->Set( Nan::New< v8::Integer >( i ), Nan::New< v8::Number >(* reinterpret_cast<int64_t *>( sqlvar->sqldata ) ) );
+					break;
+
 				case SQLFLOAT:
 				case SQLSMFLOAT:
 					result->Set( Nan::New< v8::Integer >( i ), Nan::New< v8::Number >( *sqlvar->sqldata ) );


### PR DESCRIPTION
This definitely works for reading small and large numbers from a bigserial column. I'll write you a test in another PR - but I don't know how to run them so you can take that or leave it